### PR TITLE
modif dans le bilan d'activite

### DIFF
--- a/AG2017/BilanActiv.md
+++ b/AG2017/BilanActiv.md
@@ -2,7 +2,7 @@
 
 
 ## Janvier - Février
-* 31/01 : [AG 2017](http://wiki.fablab-lannion.org/index.php?title=Compte_Rendu_AG_2017)
+* 18/01 : [AG 2016](http://wiki.fablab-lannion.org/index.php?title=Compte_Rendu_AG_2016)
 * Cycle de formation de Fabmanagers
 
 


### PR DESCRIPTION
Dans le bilan d'activité, le lien du Compte-rendu est cassé et en remontant les tweets, la dernière AG a bien eu lieu le mer 18 janv 2017